### PR TITLE
hot fix: removed mock content data

### DIFF
--- a/client/src/reducers/content.js
+++ b/client/src/reducers/content.js
@@ -1,8 +1,7 @@
 import * as actions from '../actions/types'
-import mockData from '../mockData'
 
 let initialState = {
-  current: mockData,
+  current: [],
   submitted: [],
   adminUsers: [],
   adminStories: [],
@@ -21,8 +20,8 @@ export default function stories_reducer(state = initialState, action) {
     case actions.FETCH_STORIES:
       return {
         ...state,
-        page: action.page
-        // current: action.payload
+        page: action.page,
+        current: action.payload
       }
     case actions.GET_COUNT:
       return {


### PR DESCRIPTION
This removes the mock data that was placed in lieu of the actual articles from the db. The mock data somehow got merged in after transitioning the repo